### PR TITLE
Remove hard coded stack from manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -5,4 +5,3 @@ applications:
   memory: 16M
   disk_quota: 16M
   no-route: true
-  stack: cflinuxfs2


### PR DESCRIPTION
- this breaks in envs (cf dev) where cflinuxfs2 has been removed
- cf does a good job of determining correct stack without value in manifest
- tested in both cf dev and cf.capbristol.com